### PR TITLE
Use 200ms delay for any YT pause on multiview, not just past videos

### DIFF
--- a/src/components/multiview/VideoCell.vue
+++ b/src/components/multiview/VideoCell.vue
@@ -197,7 +197,7 @@ export default {
             }
         },
         onPlayPause(paused = false) {
-            if (this.ytPlayer && this.video.status === "past") {
+            if (this.ytPlayer) {
                 setTimeout(() => {
                     const recheck = this.ytPlayer.getPlayerState() === 2;
                     this.updatePausedState(recheck);


### PR DESCRIPTION
Some livestreams have rewind enabled, and clicking on the seek bar on those currently causes the entire seek bar to shift around in the layout (messing with the seek position) due to the multiview button/border popping in as soon as the video is paused. This adds the same delay to lives as VODs such that clicking on the seekbar on live-rewind-enabled YT livestreams seeks to the correct position (dragging is still an unsupported case, for both VODs and lives, as the 200ms delay is usually not long enough to drag around in the seekbar before the seekbar shifts upwards due to the border popping in).